### PR TITLE
Update R repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,9 @@ RUN ln -s /usr/lib/R/site-library/littler/examples/update.r /usr/local/bin/updat
 # download.file.extra for Rscript
 RUN echo "options( \
     repos = \
-      c(CRAN = 'https://packagemanager.rstudio.com/all/__linux__/bionic/latest', \
-        jrpublic = 'https://rstudio.jumpingrivers.cloud/package-manager/jumpingrivers/latest',\
+      c(CRAN = 'https://rstudio.jumpingrivers.cloud/package-manager/cran/__linux__/bionic/latest', \ 
+        #CRAN = 'https://packagemanager.rstudio.com/all/__linux__/bionic/latest', \
+        jrpublic = 'https://rstudio.jumpingrivers.cloud/package-manager/jumpingrivers/latest', \
         jrpackages = 'https://jr-packages.github.io/drat/'), \
     HTTPUserAgent = sprintf('R/%s R (%s)', getRversion(),               \
                                paste(getRversion(), R.version['platform'], \

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,9 +82,9 @@ RUN ln -s /usr/lib/R/site-library/littler/examples/update.r /usr/local/bin/updat
 # download.file.extra for Rscript
 RUN echo "options( \
     repos = \
-      c(CRAN = 'https://rspm.jumpingrivers.cloud/jrPackagesCRAN/__linux__/bionic/latest', \
-        jrinternal = 'https://rspm.jumpingrivers.cloud/jrPackages/latest',\
-         jrpackages = 'https://jr-packages.github.io/drat/'), \
+      c(CRAN = 'https://packagemanager.rstudio.com/all/__linux__/bionic/latest', \
+        jrpublic = 'https://rstudio.jumpingrivers.cloud/package-manager/jumpingrivers/latest',\
+        jrpackages = 'https://jr-packages.github.io/drat/'), \
     HTTPUserAgent = sprintf('R/%s R (%s)', getRversion(),               \
                                paste(getRversion(), R.version['platform'], \
                                      R.version['arch'], R.version['os'])), \


### PR DESCRIPTION
Changed CRAN mirror to RStudio with binaries (no JR)
Changed JR Internal to JR Public (but not DRAT) only
Removed JR private packages

All repos should have distinct packages to avoid version conflicts.