### PR TITLE
add cran ppa for newest libgit2-dev on bionic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,9 @@ RUN apt-get update -qq && \
 
 # Needed for gert
 # Can add above due to conflicts
-RUN apt-get update && \
-    apt-get -y --no-install-recommends install libgit2-dev \
+RUN add-apt-repository ppa:cran/libgit2 \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install libgit2-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
{gert} seems to expect libgit2-dev v27, which is on unavailable on bionic.

This PR uses libgit2 backports provided by CRANs ppa.